### PR TITLE
[EDITOR] Remove .vscode config that should'nt be comitted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ tmp/
 typings/
 
 # Visual Studio Code
+.vscode
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,0 @@
-{
-  "recommendations": ["nativescript.nativescript"]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "nuxt.isNuxtApp": false
-}


### PR DESCRIPTION
This pull request removes the .vscode folder from the repository. This folder contains settings specific to Visual Studio Code and is not necessary for the project to function properly. Committing this folder can lead to unnecessary merge conflicts and increased repository size. I've added the folder to the .gitignore file to prevent it from being tracked in the future.